### PR TITLE
Remove unnecessary type assignments

### DIFF
--- a/packages/fhir_r4/lib/src/primitive_types/base64binary.dart
+++ b/packages/fhir_r4/lib/src/primitive_types/base64binary.dart
@@ -85,7 +85,7 @@ class FhirBase64Binary extends PrimitiveType
 
   /// Constructs a [FhirBase64Binary] from a JSON [Map].
   factory FhirBase64Binary.fromJson(Map<String, dynamic> json) {
-    final rawValue = json['value'] as String?;
+    final rawValue = json['value'];
     final elementJson = json['_value'] as Map<String, dynamic>?;
     final parsedElement =
         elementJson == null ? null : Element.fromJson(elementJson);

--- a/packages/fhir_r4/lib/src/primitive_types/canonical.dart
+++ b/packages/fhir_r4/lib/src/primitive_types/canonical.dart
@@ -106,7 +106,7 @@ class FhirCanonical extends FhirUri
 
   /// Constructs a [FhirCanonical] from a JSON [Map].
   factory FhirCanonical.fromJson(Map<String, dynamic> json) {
-    final rawValue = json['value'] as String?;
+    final rawValue = json['value'];
     final elementJson = json['_value'] as Map<String, dynamic>?;
     final parsedElement =
         elementJson == null ? null : Element.fromJson(elementJson);

--- a/packages/fhir_r4/lib/src/primitive_types/code.dart
+++ b/packages/fhir_r4/lib/src/primitive_types/code.dart
@@ -66,7 +66,7 @@ class FhirCode extends FhirString
 
   /// Constructs a [FhirCode] from JSON.
   factory FhirCode.fromJson(Map<String, dynamic> json) {
-    final rawValue = json['value'] as String?;
+    final rawValue = json['value'];
     final elementJson = json['_value'] as Map<String, dynamic>?;
     final parsedElement =
         elementJson == null ? null : Element.fromJson(elementJson);

--- a/packages/fhir_r4/lib/src/primitive_types/decimal.dart
+++ b/packages/fhir_r4/lib/src/primitive_types/decimal.dart
@@ -120,7 +120,7 @@ class FhirDecimal extends FhirNumber
 
   /// Creates a [FhirDecimal] from JSON.
   factory FhirDecimal.fromJson(Map<String, dynamic> json) {
-    final rawValue = json['value'] as num?;
+    final rawValue = json['value'];
     final elemJson = json['_value'] as Map<String, dynamic>?;
     final parsedElement = elemJson == null ? null : Element.fromJson(elemJson);
     return FhirDecimal(

--- a/packages/fhir_r4/lib/src/primitive_types/id.dart
+++ b/packages/fhir_r4/lib/src/primitive_types/id.dart
@@ -87,7 +87,7 @@ class FhirId extends FhirUri
 
   /// Constructs a [FhirId] from a JSON [Map].
   factory FhirId.fromJson(Map<String, dynamic> json) {
-    final rawValue = json['value'] as String?;
+    final rawValue = json['value'];
     final elementJson = json['_value'] as Map<String, dynamic>?;
     final parsedElement =
         elementJson == null ? null : Element.fromJson(elementJson);

--- a/packages/fhir_r4/lib/src/primitive_types/integer.dart
+++ b/packages/fhir_r4/lib/src/primitive_types/integer.dart
@@ -105,7 +105,7 @@ class FhirInteger extends FhirNumber
 
   /// Creates a [FhirInteger] from JSON.
   factory FhirInteger.fromJson(Map<String, dynamic> json) {
-    final value = json['value'] as num?;
+    final value = json['value'];
     final elemJson = json['_value'] as Map<String, dynamic>?;
     final parsedElement = elemJson == null ? null : Element.fromJson(elemJson);
     return FhirInteger(value, element: parsedElement);

--- a/packages/fhir_r4/lib/src/primitive_types/integer64.dart
+++ b/packages/fhir_r4/lib/src/primitive_types/integer64.dart
@@ -132,7 +132,7 @@ class FhirInteger64 extends PrimitiveType implements Comparable<FhirInteger64> {
 
   /// Creates a [FhirInteger64] from a JSON [Map].
   factory FhirInteger64.fromJson(Map<String, dynamic> json) {
-    final rawValue = json['value'] as String?;
+    final rawValue = json['value'];
     final elemJson = json['_value'] as Map<String, dynamic>?;
     final parsedElement = elemJson == null ? null : Element.fromJson(elemJson);
     return FhirInteger64.fromString(

--- a/packages/fhir_r4/lib/src/primitive_types/markdown.dart
+++ b/packages/fhir_r4/lib/src/primitive_types/markdown.dart
@@ -71,7 +71,7 @@ class FhirMarkdown extends FhirString
 
   /// Constructs a [FhirMarkdown] from a JSON [Map].
   factory FhirMarkdown.fromJson(Map<String, dynamic> json) {
-    final rawValue = json['value'] as String?;
+    final rawValue = json['value'];
     final elementJson = json['_value'] as Map<String, dynamic>?;
     final parsedElement =
         elementJson == null ? null : Element.fromJson(elementJson);

--- a/packages/fhir_r4/lib/src/primitive_types/number.dart
+++ b/packages/fhir_r4/lib/src/primitive_types/number.dart
@@ -107,7 +107,7 @@ abstract class FhirNumber extends PrimitiveType
   ///
   /// Uses [fromNum] internally. Expects `'value'` to be a [num].
   factory FhirNumber.fromJson(Map<String, dynamic> json) {
-    final value = json['value'] as num?;
+    final value = json['value'];
     final elementJson = json['_value'] as Map<String, dynamic>?;
     final element = elementJson == null ? null : Element.fromJson(elementJson);
 

--- a/packages/fhir_r4/lib/src/primitive_types/oid.dart
+++ b/packages/fhir_r4/lib/src/primitive_types/oid.dart
@@ -98,7 +98,7 @@ class FhirOid extends FhirUri
 
   /// Constructs a [FhirOid] from a JSON [Map].
   factory FhirOid.fromJson(Map<String, dynamic> json) {
-    final rawValue = json['value'] as String?;
+    final rawValue = json['value'];
     final elementJson = json['_value'] as Map<String, dynamic>?;
     final parsedElement =
         elementJson == null ? null : Element.fromJson(elementJson);

--- a/packages/fhir_r4/lib/src/primitive_types/positive_int.dart
+++ b/packages/fhir_r4/lib/src/primitive_types/positive_int.dart
@@ -110,7 +110,7 @@ class FhirPositiveInt extends FhirNumber
 
   /// Constructs a [FhirPositiveInt] from a JSON [Map].
   factory FhirPositiveInt.fromJson(Map<String, dynamic> json) {
-    final rawValue = json['value'] as num?;
+    final rawValue = json['value'];
     final elemJson = json['_value'] as Map<String, dynamic>?;
     final parsedElement = elemJson == null ? null : Element.fromJson(elemJson);
 

--- a/packages/fhir_r4/lib/src/primitive_types/time.dart
+++ b/packages/fhir_r4/lib/src/primitive_types/time.dart
@@ -100,7 +100,7 @@ class FhirTime extends PrimitiveType
 
   /// Constructs a [FhirTime] from a JSON [Map].
   factory FhirTime.fromJson(Map<String, dynamic> json) {
-    final rawValue = json['value'] as String?;
+    final rawValue = json['value'];
     final elemJson = json['_value'] as Map<String, dynamic>?;
     final parsedElement = elemJson == null ? null : Element.fromJson(elemJson);
     return FhirTime(rawValue, element: parsedElement);

--- a/packages/fhir_r4/lib/src/primitive_types/unsigned_int.dart
+++ b/packages/fhir_r4/lib/src/primitive_types/unsigned_int.dart
@@ -116,7 +116,7 @@ class FhirUnsignedInt extends FhirNumber
 
   /// Constructs a [FhirUnsignedInt] from a JSON [Map].
   factory FhirUnsignedInt.fromJson(Map<String, dynamic> json) {
-    final rawValue = json['value'] as num?;
+    final rawValue = json['value'];
     final elemJson = json['_value'] as Map<String, dynamic>?;
     final parsedElement = elemJson == null ? null : Element.fromJson(elemJson);
     return FhirUnsignedInt(

--- a/packages/fhir_r4/lib/src/primitive_types/uri.dart
+++ b/packages/fhir_r4/lib/src/primitive_types/uri.dart
@@ -110,7 +110,7 @@ class FhirUri extends PrimitiveType
 
   /// Constructs a [FhirUri] from a JSON [Map].
   factory FhirUri.fromJson(Map<String, dynamic> json) {
-    final rawValue = json['value'] as String?;
+    final rawValue = json['value'];
     final elementJson = json['_value'] as Map<String, dynamic>?;
     final parsedElement =
         elementJson == null ? null : Element.fromJson(elementJson);

--- a/packages/fhir_r4/lib/src/primitive_types/url.dart
+++ b/packages/fhir_r4/lib/src/primitive_types/url.dart
@@ -100,7 +100,7 @@ class FhirUrl extends FhirUri
 
   /// Constructs a [FhirUrl] from a JSON [Map].
   factory FhirUrl.fromJson(Map<String, dynamic> json) {
-    final rawValue = json['value'] as String?;
+    final rawValue = json['value'];
     final elementJson = json['_value'] as Map<String, dynamic>?;
     final parsedElement =
         elementJson == null ? null : Element.fromJson(elementJson);

--- a/packages/fhir_r4/lib/src/primitive_types/uuid.dart
+++ b/packages/fhir_r4/lib/src/primitive_types/uuid.dart
@@ -111,7 +111,7 @@ class FhirUuid extends FhirUri
 
   /// Constructs a [FhirUuid] from a JSON [Map].
   factory FhirUuid.fromJson(Map<String, dynamic> json) {
-    final rawValue = json['value'] as String?;
+    final rawValue = json['value'];
     final elementJson = json['_value'] as Map<String, dynamic>?;
     final parsedElement =
         elementJson == null ? null : Element.fromJson(elementJson);

--- a/packages/fhir_r4/lib/src/primitive_types/xhtml.dart
+++ b/packages/fhir_r4/lib/src/primitive_types/xhtml.dart
@@ -83,7 +83,7 @@ class FhirXhtml extends PrimitiveType {
 
   /// Constructs a [FhirXhtml] from a JSON [Map].
   factory FhirXhtml.fromJson(Map<String, dynamic> json) {
-    final rawValue = json['value'] as String?;
+    final rawValue = json['value'];
     final elementJson = json['_value'] as Map<String, dynamic>?;
     final parsedElement =
         elementJson == null ? null : Element.fromJson(elementJson);


### PR DESCRIPTION
Previously, primitive types parsed from JSON were being force-assigned, which caused errors when encountering other valid types. These cases are already handled in the constructor, which is called in every fromJson function. This change removes the redundant type enforcement and prevents unnecessary errors.