### PR TITLE
Call equalsDeep in == operator

### DIFF
--- a/packages/fhir_r4/lib/src/abstract_types/fhir_base.dart
+++ b/packages/fhir_r4/lib/src/abstract_types/fhir_base.dart
@@ -46,6 +46,11 @@ abstract class FhirBase {
     return o != null;
   }
 
+  @override
+  bool operator ==(Object other) {
+    return other is FhirBase && equalsDeep(other);
+  }
+
   /// Checks if the object is equal to another object.
   // ignore: avoid_positional_boolean_parameters
   bool compareDeepStrings(String? s1, String? s2, bool allowNull) {


### PR DESCRIPTION
- All entities call equalsDeep when using `==` operator
- Solves https://github.com/fhir-fli/fhir_r4/issues/23