### PR TITLE
Copy with fix

### DIFF
--- a/packages/fhir_r4/lib/src/data_types/timing.g.dart
+++ b/packages/fhir_r4/lib/src/data_types/timing.g.dart
@@ -73,7 +73,7 @@ abstract class $TimingRepeatCopyWith<T> extends $ElementCopyWith<T> {
   T call({
     FhirString? id,
     List<FhirExtension>? extension_,
-    FhirDuration? boundsX,
+    BoundsXTimingRepeat? boundsX,
     FhirPositiveInt? count,
     FhirPositiveInt? countMax,
     FhirDecimal? duration,
@@ -127,7 +127,7 @@ class _$TimingRepeatCopyWithImpl<T> implements $TimingRepeatCopyWith<T> {
             : extension_ as List<FhirExtension>?,
         boundsX: identical(boundsX, fhirSentinel)
             ? _value.boundsX
-            : boundsX as FhirDuration?,
+            : boundsX as BoundsXTimingRepeat?,
         count: identical(count, fhirSentinel)
             ? _value.count
             : count as FhirPositiveInt?,


### PR DESCRIPTION
There is a bug with incorrect types passed to copyWith method. Instead of base class representation it shows one of the possible derived class